### PR TITLE
Distinguish ACME clients

### DIFF
--- a/install-acme.yml
+++ b/install-acme.yml
@@ -7,6 +7,7 @@
 #* details.
 #*  No arguments are mandatory.
 
+# Do only on hosts with the acme-tiny application actually installed
 - hosts: app.acme.tiny
   become: True
   roles:

--- a/setup-lets-encrypt.yml
+++ b/setup-lets-encrypt.yml
@@ -8,22 +8,15 @@
 
 - include: install-acme.yml
 
-- hosts: app.acme.tiny
+# Do on all hosts related to acme
+- hosts: app.acme
   become: True
   roles:
     - zwischenloesung.acme-tiny-setup
 
+# Do only on hosts with the acme-tiny application actually installed
 - hosts: app.acme.tiny
   become: True
   roles:
     - zwischenloesung.acme-tiny
-
-# not enabling this yet, as it only tracks 'today'
-# it is only useful for human communication and needs
-# to be combined with something smarter as
-# dpkg --get-selections
-#- hosts: all
-
-#  roles:
-#    - track-packages
 


### PR DESCRIPTION
Some consumers of certificates can directly order certs, other must
request them via a proxy host.