### PR TITLE
Match the playbook to the backend

### DIFF
--- a/install-apache.yml
+++ b/install-apache.yml
@@ -13,10 +13,14 @@
 
   vars:
     apache__default_vhost:
-      name: '{{ ansible_fqdn }}'
+      name: '{{ fqdn }}'
       root: '/var/www/html'
       # don't enforce https by default
       redirect_to_https: False
+# TODO: does not work yet, mainly because of the 'raw' format which is
+# not supported in reclass
+# TODO: should this be a simple mapping here or a mandatory argument
+#    apache__vhosts: '{{ app__apache__vhosts }}'
 
   roles:
     - debops.apache/env


### PR DESCRIPTION
In maestro/reclass we use fqdn and app__ namespace. Furthermore the raw
format is not supported in the reclass yaml (TODO).