### PR TITLE
Replace "iteritems()" by "items()" for jinja

### DIFF
--- a/install-webserver.yml
+++ b/install-webserver.yml
@@ -15,7 +15,7 @@
   vars:
     app__apache__mod_pkgs: '{{ os__pkg_name.apache_mod[os__short] | d(os__pkg_name.apache_mod[os__distro]) }}'
 ##    app__apache__mods: '{{ app__apache__modules | list() | unique() }}'
-    app__apache__mod_helper: '{% for key, value in app__apache__modules.iteritems() %}{% if value == True %}{{ app__apache__mod_pkgs[key] | d() }};{% endif %}{% endfor %}'
+    app__apache__mod_helper: '{% for key, value in app__apache__modules.items() %}{% if value == True %}{{ app__apache__mod_pkgs[key] | d() }};{% endif %}{% endfor %}'
     app__apache__yapkg__names: '{{ os__pkg_name.apache[os__short] | d(os__pkg_name.apache[os__distro]) }} + {{ app__apache__mod_helper.split(";") }}'
 
     # use fqdn if ansible_fqdn is not set

--- a/roles/virt-install/templates/inofix_base.j2
+++ b/roles/virt-install/templates/inofix_base.j2
@@ -21,7 +21,7 @@ Defaults: %inofix env_check += "SSH_CLIENT"
 %inofix ALL = (ALL:ALL) NOPASSWD: SETENV: ALL
 EOF
 
-{% for adminname, admin in admins.iteritems() %}
+{% for adminname, admin in admins.items() %}
 in-target useradd -u "{{ admin.uid }}" -G inofix -c "{{ admin.fullname }}" -s /bin/bash -m "{{ admin.username }}"
 #in-target chage -d 0 "{{ admin.username }}"
 mkdir -p "/target/home/{{ admin.username }}/.ssh"


### PR DESCRIPTION
`items()` is inefficient for Python 2 but compatible with Python 3.

See [docs.ansible.com: dict.iteritems()](https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems)