### PR TITLE
Replace removed 'sudo' option with 'become'

### DIFF
--- a/roles/unset-credentials/tasks/main.yml
+++ b/roles/unset-credentials/tasks/main.yml
@@ -5,7 +5,7 @@
     line: "{{ format[file_type].line }}"
     regexp: "{{ format[file_type].regexp }}"
 # This always happens locally in the workdir..
-  sudo: false
+  become: false
   connection: local
   with_items: "{{ file_list }}"
 

--- a/roles/unset-password/tasks/main.yml
+++ b/roles/unset-password/tasks/main.yml
@@ -4,7 +4,7 @@
     regexp: "^{{ account_pass_key }}=.*"
     line: "{{ account_pass_key }}={{ account_password_placeholder }}"
 # This always happens locally in the workdir..
-  sudo: false
+  become: false
   connection: local
   when: account_dest_file_type == "key=val"
 
@@ -14,7 +14,7 @@
     regexp: "^{{ account_pass_key }} = .*"
     line: "{{ account_pass_key }} = {{ account_password_placeholder }}"
 # This always happens locally in the workdir..
-  sudo: false
+  become: false
   connection: local
   when: account_dest_file_type == "key = val"
 
@@ -25,7 +25,7 @@
     line: '\1"{{ account_pass_key }}": "{{ account_password_placeholder }}"\2'
     backrefs: yes
 # This always happens locally in the workdir..
-  sudo: false
+  become: false
   connection: local
   when: account_dest_file_type == "json"
 


### PR DESCRIPTION
The 'sudo' option was replaced with 'become' since at least Ansible 2.1.
Ansible 2.9 has now finally removed 'sudo'. This fixes playbook
compatilibity with newer Ansible versions.